### PR TITLE
Adds a way to fix Grafana's permission problems

### DIFF
--- a/docs/apps/grafana.md
+++ b/docs/apps/grafana.md
@@ -1,4 +1,4 @@
-## Fix for permission problems
+# Fix for permission problems
 
 If you see the following error:
 
@@ -18,13 +18,12 @@ Where UID and GID is the one configured on DockSTARTer, and Grafana's appdata fo
 If you don't know the variables needed above, is rather simple to check:
 
 1. Run DockSTARTer (`sudo ds`)
-2. Chooses `Configuration`
-3. Select `Set Global Variables`
-4. Your DockSTARTer variables will be displayed, you're looking for the `PUID=`, `PGID=` and `DOCKERCONFDIR=`values.
+1. Chooses `Configuration`
+1. Select `Set Global Variables`
+1. Your DockSTARTer variables will be displayed, you're looking for the `PUID=`, `PGID=` and `DOCKERCONFDIR=`values.
 
 > `PUID` is UID;
-
+>
 > `PGID` is GID;
-
+>
 > `DOCKERCONFDIR` is DS' appdata folder, just append `/grafana/` to get Grafana's appdata folder.
-

--- a/docs/apps/grafana.md
+++ b/docs/apps/grafana.md
@@ -12,20 +12,3 @@ GF_PATHS_DATA='/var/lib/grafana' is not writable.
 Run the following command to fix it:
 
 `sudo chown -R $USER:$USER ~/.config/appdata/grafana`
-
-Where UID and GID is the one configured on DockSTARTer, and Grafana's appdata folder is DockSTARTer's appdata folder appended with /grafana/ (e.g.: /home/username/.config/appdata/grafana/).
-
-## Checking your variables
-
-If you don't know the variables needed above, is rather simple to check:
-
-1. Run DockSTARTer (`sudo ds`)
-1. Chooses `Configuration`
-1. Select `Set Global Variables`
-1. Your DockSTARTer variables will be displayed, you're looking for the `PUID=`, `PGID=` and `DOCKERCONFDIR=`values.
-
-> `PUID` is UID;
->
-> `PGID` is GID;
->
-> `DOCKERCONFDIR` is DS' appdata folder, just append `/grafana/` to get Grafana's appdata folder.

--- a/docs/apps/grafana.md
+++ b/docs/apps/grafana.md
@@ -1,4 +1,6 @@
-# Fix for permission problems
+# Grafana
+
+## Fix for permission problems
 
 If you see the following error:
 

--- a/docs/apps/grafana.md
+++ b/docs/apps/grafana.md
@@ -1,1 +1,30 @@
-Placeholder page
+## Fix for permission problems
+
+If you see the following error:
+
+```
+mkdir: cannot create directory '/var/lib/grafana/plugins': Permission denied,
+GF_PATHS_DATA='/var/lib/grafana' is not writable.
+```
+
+Run the following command to fix it:
+
+`sudo chown [UID]:[GID] [Grafana/appdata/folder]`
+
+Where UID and GID is the one configured on DockSTARTer, and Grafana's appdata folder is DockSTARTer's appdata folder appended with /grafana/ (e.g.: /home/username/.config/appdata/grafana/).
+
+### Checking your variables
+
+If you don't know the variables needed above, is rather simple to check:
+
+1. Run DockSTARTer (`sudo ds`)
+2. Chooses `Configuration`
+3. Select `Set Global Variables`
+4. Your DockSTARTer variables will be displayed, you're looking for the `PUID=`, `PGID=` and `DOCKERCONFDIR=`values.
+
+> `PUID` is UID;
+
+> `PGID` is GID;
+
+> `DOCKERCONFDIR` is DS' appdata folder, just append `/grafana/` to get Grafana's appdata folder.
+

--- a/docs/apps/grafana.md
+++ b/docs/apps/grafana.md
@@ -13,7 +13,7 @@ Run the following command to fix it:
 
 Where UID and GID is the one configured on DockSTARTer, and Grafana's appdata folder is DockSTARTer's appdata folder appended with /grafana/ (e.g.: /home/username/.config/appdata/grafana/).
 
-### Checking your variables
+## Checking your variables
 
 If you don't know the variables needed above, is rather simple to check:
 

--- a/docs/apps/grafana.md
+++ b/docs/apps/grafana.md
@@ -11,7 +11,7 @@ GF_PATHS_DATA='/var/lib/grafana' is not writable.
 
 Run the following command to fix it:
 
-`sudo chown $USER:$USER [Grafana/appdata/folder]`
+`sudo chown -R $USER:$USER ~/.config/appdata/grafana`
 
 Where UID and GID is the one configured on DockSTARTer, and Grafana's appdata folder is DockSTARTer's appdata folder appended with /grafana/ (e.g.: /home/username/.config/appdata/grafana/).
 

--- a/docs/apps/grafana.md
+++ b/docs/apps/grafana.md
@@ -11,7 +11,7 @@ GF_PATHS_DATA='/var/lib/grafana' is not writable.
 
 Run the following command to fix it:
 
-`sudo chown [UID]:[GID] [Grafana/appdata/folder]`
+`sudo chown $USER:$USER [Grafana/appdata/folder]`
 
 Where UID and GID is the one configured on DockSTARTer, and Grafana's appdata folder is DockSTARTer's appdata folder appended with /grafana/ (e.g.: /home/username/.config/appdata/grafana/).
 


### PR DESCRIPTION
Grafana container has a weird behavior regarding volumes and writing permissions, which might result on it hanging if it's folder is not given the right permissions.

This entry aims to guide the user on how to fix the issue.